### PR TITLE
Add payload access like attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,22 @@ This is done by passing the third argument as an array to the ```->tagIt(...)```
 
 Getting payload data:
 
+There are 2 ways to get payload data :
+
+You can use `getPayload` method 
 ```php
   $tagObj->getPayload('reason');       //  'You were nasty!'      
   $tagObj->getPayload();               //  ['reason' => 'You were nasty!'] 
   $tagObj->getPayload('missing_key');  //  null
 ```
+
+or You can act like eloquent attributes :
+```php
+  $tagObj->reason;       //  'You were nasty!'      
+  $tagObj->payload;      //  ['reason' => 'You were nasty!'] 
+  $tagObj->missing_key;  //  null
+```
+
 
 --------------
 

--- a/src/Models/TempTag.php
+++ b/src/Models/TempTag.php
@@ -133,4 +133,13 @@ class TempTag extends Model
             // laravel does not fully support incrementing json values.
         }
     }
+
+    public function getAttribute($key)
+    {
+        if(!is_null($this->getPayload($key))){
+            return $this->getPayload($key);
+        }
+
+        return parent::getAttribute($key);
+    }
 }

--- a/tests/Unit/SampleTest.php
+++ b/tests/Unit/SampleTest.php
@@ -47,11 +47,13 @@ class SampleTest extends TestCase
         cache()->store('temp_tag')->flush();
         $this->assertTrue(tempTags($user)->getTag('banned')->isActive());
 
-        tempTags($user)->tagIt('banned_for', $tomorrow, ['count' => 1]);
+        tempTags($user)->tagIt('banned_for', $tomorrow, ['count' => 1, 'ban_level' => 'hard']);
         $tag = tempTags($user)->getTag('banned_for');
         $this->assertEquals(1, $tag->getPayload('count'));
-        $this->assertEquals(['count' => 1], $tag->getPayload());
-        $this->assertEquals(['count' => 1], $tag->payload);
+        $this->assertEquals(1, $tag->count);
+        $this->assertEquals('hard', $tag->ban_level);
+        $this->assertEquals(['count' => 1, 'ban_level' => 'hard'], $tag->getPayload());
+        $this->assertEquals(['count' => 1, 'ban_level' => 'hard'], $tag->payload);
         tempTags($user)->unTag('banned_for');
         // =================== test expired tag =====================
 


### PR DESCRIPTION
Now everybody can access the payload data like other attributes in the model.
Before that to access a payload data you should have writen something like :
```php
$tag = tempTags($user)->tagIt('ban', $tomorrow, ['level' => 'hard']);
$tag->getPayload('level');
```
Now You can write : 
```php
$tag = tempTags($user)->tagIt('ban', $tomorrow, ['level' => 'hard']);
$tag->level;
```